### PR TITLE
Add hashbang, fix CLI example in readme, add `script` for installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In the above tables, the ``''`` designates strings. **Any UNKNOWN taxonomic leve
 ### Command line:
 
 ```bash
-python taxumap/run_taxumap.py -t taxonomy.csv -m microbiota_table.csv
+run_taxumap.py -t examples/example_data/taxonomy.csv -m examples/example_data/microbiota_table.csv
 ```
 The embedding will be saved in the current working folder, or to a location with the `-o path/to/folder/` flag. Additionally, for best results, the flag `-n` should be folllowed by the number of unique patients in your dataset (see **Optional** flag information below for more details).
 

--- a/run_taxumap.py
+++ b/run_taxumap.py
@@ -1,10 +1,11 @@
+#! /usr/bin/env python3
 # Authors: Jonas Schluter <jonas.schluter@nyulangone.org>, Grant Hussey <grant.hussey@nyulangone.org>
 # License: MIT
 import argparse
 import numpy as np
 import os
 import warnings
-import sys 
+import sys
 
 from taxumap.taxumap_base import Taxumap
 

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    scripts=['run_taxumap.py'],
     zip_safe=False,
 )


### PR DESCRIPTION
Hello!  I am excited to be using taxumap.  These changes allow the tool to be run via the `run_taxumap.py` script in the repo by adding it to the package install.   I've also fixed the usage example for the CLI interface in the docs.  